### PR TITLE
MRNowPlayingInfo fix

### DIFF
--- a/Sources/MusicPlayer/Utilities/MediaRemoteHelper.swift
+++ b/Sources/MusicPlayer/Utilities/MediaRemoteHelper.swift
@@ -63,7 +63,7 @@ struct MRNowPlayingInfo {
         if let id = _uniqueIdentifier {
             return id.description
         } else if let title = _title {
-            return "NowPlaying-\(title)-\(_album ?? "")-\(_duration.map(Int.init) ?? 0)"
+            return "NowPlaying-\(title)\(_album.map { "-\($0)" } ?? "")"
         } else {
             return nil
         }


### PR DESCRIPTION
通过Lyricsx本地编译后排查到，_duration可能会Inf()，引发后续报错并强制退出
_duration may Inf(), causing subsequent errors and forcing the exit

> Swift/arm64e-apple-macos.swiftinterface:39218: Fatal error: Double value cannot be converted to Int because it is either infinite or NaN
> (lldb) print _duration
> (NSTimeInterval?) +Inf
<img width="289" alt="image" src="https://github.com/user-attachments/assets/a176e6b8-d21b-4ffb-969a-8d8063cae10d" />

可通过特判优化，不过上下阅读了下源码，认为duration的展示可以移去
We can use technique to fix, but it will cause the code to be slightly complicated, and it is not very applicable. I think we can remove 'duration' in title(id).