### PR TITLE
fix: 将 setPlayerState 的容差从 1.5s 收到 0.2s

### DIFF
--- a/Sources/LXMusicPlayer/LXScriptingMusicPlayer.m
+++ b/Sources/LXMusicPlayer/LXScriptingMusicPlayer.m
@@ -86,7 +86,14 @@
 - (void)setPlaybackTime:(NSTimeInterval)playbackTime {}
 
 - (void)setPlayerState:(LXPlayerState *)playerState tolerate:(NSTimeInterval)tolerate {
-    if (![self.playerState isApproximateEqualToState:playerState tolerate:tolerate]) {
+    // Caller-supplied `tolerate` (historically 1.5s for all scriptable players)
+    // suppresses any drift correction smaller than that threshold. For lyric
+    // synchronization that's an entire line of latency. Clamp internally to
+    // 0.2s — still 4x the typical Apple Events RPC jitter (~50ms), so steady
+    // playback won't trigger spurious publishes, but real drift from buffering
+    // or repeat-one wrap-around gets corrected on the next manual update tick.
+    NSTimeInterval effectiveTolerate = MIN(tolerate, 0.2);
+    if (![self.playerState isApproximateEqualToState:playerState tolerate:effectiveTolerate]) {
         self.playerState = playerState;
     }
 }


### PR DESCRIPTION
## 问题

若点击播放后播放器由于网络原因等没有立刻播放，其 实际播放出来的时刻 和 点击播放的时刻 的差值除以 1.5s 取余 会成为这首歌歌词的延迟，持续直到歌曲结束。手动暂停并继续播放才可以重新校准。

## 分析

- `PlaybackState.time` 是按捕获的 `Date` 推算的，state 没被替换时插值就一直按墙上时钟往前跑。
- [主仓库PR](https://github.com/MxIris-LyricsX-Project/LyricsX/pull/148)的 1Hz 的 `updatePlayerState` 本应把它定位到真实位置。但所有调用点都传 `tolerate:1.5`，任何小于 1.5s 的纠正都被吞掉。

## 改动

```objc
- if (![self.playerState isApproximateEqualToState:playerState tolerate:tolerate]) {
+ NSTimeInterval effectiveTolerate = MIN(tolerate, 0.2);
+ if (![self.playerState isApproximateEqualToState:playerState tolerate:effectiveTolerate]) {
```

## 另

publish 频率会比之前略升。 LyricsX PR 已经加了 等价 state 重渲染的去重。

